### PR TITLE
Remove duplicated restart definition

### DIFF
--- a/file-inclusion/college_website/docker-compose.yml
+++ b/file-inclusion/college_website/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     restart: 'always'
     depends_on:
       - mariadb
-    restart: 'always'
     ports:
       - '8081:80'
     links:


### PR DESCRIPTION
Duplicating the definition was causing errors:

```sh
docker compose up -d
parsing docker-labs/file-inclusion/college_website/docker-compose.yml: yaml: unmarshal errors:
  line 9: mapping key "restart" already defined at line 6
```